### PR TITLE
UPSTREAM: <carry>: OCP specific build scripts and Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -303,3 +303,9 @@ push-ci-image:
 
 print-ci-image:
 	@$(MAKE) --no-print-directory -C hack/images/ci print
+
+## --------------------------------------
+## Openshift specific include
+## --------------------------------------
+
+include openshift.mk

--- a/openshift-hack/build-go.sh
+++ b/openshift-hack/build-go.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu
+
+
+REPO=github.com/openshift/cloud-provider-vsphere
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WHAT=${1:-cloud-controller-manager}
+GLDFLAGS=${GLDFLAGS:-}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+: "${GOOS:=${GOHOSTOS}}"
+: "${GOARCH:=${GOHOSTARCH}}"
+
+cd "$REPO_ROOT"
+if [ -z ${VERSION_OVERRIDE+a} ]; then
+	echo "Using version from git..."
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
+fi
+
+GLDFLAGS="-extldflags '-static' -w -s"
+GLDFLAGS="$GLDFLAGS -X main.version=${VERSION_OVERRIDE}"
+GLDFLAGS="$GLDFLAGS -X k8s.io/kubernetes/pkg/version.gitVersion=${VERSION_OVERRIDE}"
+GLDFLAGS="$GLDFLAGS -X k8s.io/component-base/pkg/version.gitVersion=${VERSION_OVERRIDE}"
+
+eval $(go env)
+
+echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
+GO111MODULE=${GO111MODULE} CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o .build/${WHAT} ${REPO_ROOT}/cmd/${WHAT}

--- a/openshift-hack/check-fmt.sh
+++ b/openshift-hack/check-fmt.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ./openshift-hack/go-get-tool.sh
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$REPO_ROOT"
+
+function runGoimports() {
+    # Goimports acting like gofmt. So, no need to rum fmt separately
+    local GOIMPORTS_PATH=$LOCAL_BINARIES_PATH/goimports
+    go-get-tool "$GOIMPORTS_PATH" golang.org/x/tools/cmd/goimports
+    $GOIMPORTS_PATH -e -w ./cmd/ ./pkg/
+    echo "fmt and goimports done"
+}
+
+function gitDiff() {
+    git diff --exit-code
+}
+
+function runFmt() {
+    runGoimports
+
+    if [ "$OPENSHIFT_CI" == "true" ]; then
+        gitDiff
+    fi
+}
+
+runFmt

--- a/openshift-hack/check-lint.sh
+++ b/openshift-hack/check-lint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ./openshift-hack/go-get-tool.sh
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$REPO_ROOT"
+
+function runGolint() {
+    local GOLINT_PATH=$LOCAL_BINARIES_PATH/golint
+    go-get-tool "$GOLINT_PATH" golang.org/x/lint/golint
+    $GOLINT_PATH -set_exit_status ./pkg/... ./cmd/...
+    echo "Done golint"
+}
+
+runGolint

--- a/openshift-hack/check-staticcheck.sh
+++ b/openshift-hack/check-staticcheck.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source ./openshift-hack/go-get-tool.sh
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+
+# Change directories to the parent directory of the one in which this
+# script is located.
+cd "$REPO_ROOT"
+
+CHECKS="all,-ST1*,-SA1019"
+STATICCHECK_VERSION="2021.1.1"
+
+function runStaticcheck() {
+    local STATICCHECK_PATH=$LOCAL_BINARIES_PATH/staticcheck
+    go-get-tool "$STATICCHECK_PATH" honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION
+    $STATICCHECK_PATH -checks "${CHECKS}" ./...
+    echo "Done staticcheck"
+}
+
+runStaticcheck

--- a/openshift-hack/go-get-tool.sh
+++ b/openshift-hack/go-get-tool.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+export LOCAL_BINARIES_PATH=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")/.build
+
+# go-get-tool check if binary $1 presented, if not 'go get' package $2 and install it.
+function go-get-tool() {
+    if [ -f "$1" ] ; then
+        echo "$1 already exists"
+        return
+    fi
+
+    local TMP_DIR=$(mktemp -d)
+    pushd "$TMP_DIR"
+        go mod init tmp
+        echo "Downloading $2"
+        GOBIN=$LOCAL_BINARIES_PATH go get "$2"
+    popd
+    rm -rf "$TMP_DIR"
+}

--- a/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
+++ b/openshift-hack/images/cloud-controller-manager-openshift.Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
+WORKDIR /go/src/github.com/openshift/cloud-provider-vsphere
+COPY . .
+
+RUN make binaries
+
+FROM registry.ci.openshift.org/ocp/4.10:base
+COPY --from=builder /go/src/github.com/openshift/cloud-provider-vsphere/.build/vsphere-cloud-controller-manager /bin/vsphere-cloud-controller-manager
+
+LABEL description="vSphere Cloud Controller Manager"
+
+ENTRYPOINT ["/bin/vsphere-cloud-controller-manager"]

--- a/openshift-hack/test-unit-ci.sh
+++ b/openshift-hack/test-unit-ci.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Openshift specific test runner scripts. Based on OCP CCCMO one
+# https://github.com/openshift/cluster-cloud-controller-manager-operator/blob/master/hack/unit-tests.sh
+
+source ./openshift-hack/go-get-tool.sh
+
+REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
+ENVTEST_VERSION=v0.6.5 # based on version declared in go.mod
+ENVTEST_ASSETS_DIR=/tmp/testbin
+ENVTEST_SETUP_SCRIPT=https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/${ENVTEST_VERSION}/hack/setup-envtest.sh
+
+# Use envtest install scripts instead of manual pulling and moving kubebuilder to PATH
+function setupEnvtest() {
+    echo "Envtest version: ${ENVTEST_VERSION}."
+    mkdir -p ${ENVTEST_ASSETS_DIR}
+    test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh ${ENVTEST_SETUP_SCRIPT}
+    source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh
+    fetch_envtest_tools ${ENVTEST_ASSETS_DIR}
+    setup_envtest_env ${ENVTEST_ASSETS_DIR}
+
+    # Ensure that some home var is set and that it's not the root
+    export HOME=${HOME:=/tmp/kubebuilder/testing}
+    if [ $HOME == "/" ]; then
+      export HOME=/tmp/kubebuilder/testing
+    fi
+}
+
+OPENSHIFT_CI=${OPENSHIFT_CI:-""}
+ARTIFACT_DIR=${ARTIFACT_DIR:-""}
+
+function go_test() {
+    local PKGS_WITH_TESTS
+    PKGS_WITH_TESTS=$(find . -name "*_test.go" -type f -exec dirname \{\} \;)
+    go test -v -tags=unit $PKGS_WITH_TESTS
+}
+
+runTestCI() {
+    local GO_JUNIT_REPORT_PATH=$LOCAL_BINARIES_PATH/go-junit-report
+    echo "CI env detected, run tests with jUnit report extraction"
+    if [ -n "$ARTIFACT_DIR" ] && [ -d "$ARTIFACT_DIR" ]; then
+        local JUNIT_LOCATION="$ARTIFACT_DIR"/junit_cluster_cloud_controller_manager_operator.xml
+        echo "jUnit location: $JUNIT_LOCATION"
+        go-get-tool "$GO_JUNIT_REPORT_PATH" github.com/jstemmer/go-junit-report
+        go_test -v | tee >($GO_JUNIT_REPORT_PATH > "$JUNIT_LOCATION")
+    else
+        echo "\$ARTIFACT_DIR not set or does not exists, no jUnit will be published"
+        go_test
+    fi
+}
+
+function runTests() {
+    if [ "$OPENSHIFT_CI" == "true" ]; then
+        runTestCI
+    else
+        go_test
+    fi
+}
+
+pushd $REPO_ROOT
+  setupEnvtest && \
+  runTests
+popd

--- a/openshift-hack/verify-history.sh
+++ b/openshift-hack/verify-history.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies git commits starting from predefined prefix.
+
+# default to checking most recent commit only if not run by CI pipeline
+check_base="${PULL_BASE_SHA:-HEAD^}"
+check_sha="${PULL_PULL_SHA:-HEAD}"
+
+read -d '' help_message << EOF
+commit messages should look like one of:
+UPSTREAM: <carry>: message  (commits that should be carried indefinitely)
+UPSTREAM: <drop>: message   (commits that should be dropped on the next upstream rebase)
+UPSTREAM: 1234: message     (commits that should be carried until an upstream rebase includes upstream PR 1234)
+EOF
+
+prefix='UPSTREAM: ([0-9]+|<(carry|drop)>): '
+
+echo "examining commits between $check_base and $check_sha"
+echo
+
+while read -r message; do
+  if ! [[ "$message" =~ ^$prefix ]]; then
+    echo "Git history in this PR doesn't conform to set commit message standards. Offending commit message is:"
+    echo "$message"
+    echo
+    echo "$help_message"
+    exit 1
+  fi
+  echo "$message"
+done < <(git log "$check_base".."$check_sha" --pretty=%s --no-merges)
+
+echo
+echo "All looks good"

--- a/openshift.mk
+++ b/openshift.mk
@@ -1,0 +1,34 @@
+## --------------------------------------
+## Openshift specific make targets,
+## intended to be included in root Makefile in this repository along with openshift-hack folder.
+## --------------------------------------
+
+vsphere-cloud-controller-manager:
+	openshift-hack/build-go.sh vsphere-cloud-controller-manager
+.PHONY: vsphere-cloud-controller-manager
+
+binaries: vsphere-cloud-controller-manager
+.PHONY: binaries
+
+verify-history:
+	openshift-hack/verify-history.sh
+.PHONY: verify-history
+
+fmt:
+	openshift-hack/check-fmt.sh
+.PHONY: fmt
+
+lint:
+	openshift-hack/check-lint.sh
+.PHONY: lint
+
+staticcheck:
+	openshift-hack/check-staticcheck.sh
+.PHONY: staticcheck
+
+verify: fmt vet lint staticcheck
+.PHONY: verify
+
+test-unit-ci unit:
+	openshift-hack/test-unit-ci.sh
+.PHONY: test-unit-ci unit


### PR DESCRIPTION
Added Openshift specific builds scripts, linter/tests/etc runners. Extended makefile with OCP specific targets.

Upstream version of lint, fmt and staticcheck pollutes go.mod and go.sum files, so, own versions of such scripts was introduced.