### PR TITLE
UPSTREAM: <carry>: fix staticcheck cache in openshift ci

### DIFF
--- a/openshift-hack/check-staticcheck.sh
+++ b/openshift-hack/check-staticcheck.sh
@@ -33,6 +33,13 @@ STATICCHECK_VERSION="2021.1.1"
 function runStaticcheck() {
     local STATICCHECK_PATH=$LOCAL_BINARIES_PATH/staticcheck
     go-get-tool "$STATICCHECK_PATH" honnef.co/go/tools/cmd/staticcheck@$STATICCHECK_VERSION
+
+    # Ensure that some home var is set and that it's not the root
+    export HOME=${HOME:=/tmp/temphome}
+    if [ $HOME == "/" ]; then
+      export HOME=/tmp/temphome
+    fi
+
     $STATICCHECK_PATH -checks "${CHECKS}" ./...
     echo "Done staticcheck"
 }


### PR DESCRIPTION
HOME variable in containers might be equal /, which causing
issues with staticcheck in openshift ci. Added check for HOME
in staticcheck run script.

Affected ci run: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/21715/rehearse-21715-pull-ci-openshift-cloud-provider-vsphere-master-verify/1437371034817794048