### PR TITLE
fix .dockerignore to satisfy OCP specific requirements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,10 +12,6 @@
 # Ignore marker files.
 **/*.d
 
-# Ignore any Dockerfiles at the root of the project.
-/Dockerfile*
-
-*.json
 *.sublime-project
 *.sublime-workspace
 *.swp
@@ -153,7 +149,3 @@ zz_generated.openapi.go
 
 # binaries
 /vsphere-cloud-controller-manager
-
-
-# Openshift specific exclusions
-!*.assembly.stream.json


### PR DESCRIPTION
Apparently, OSBS relies on adding specific Dockerfile during an image build.

Having `Dockerfile*` and `*.json` patterns in `.dockerignore` cause issues.