### PR TITLE
Bug 2106666: Return error when VM's info returned from VC doesn't contain IP address

### DIFF
--- a/pkg/cloudprovider/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/vsphere/nodemanager.go
@@ -207,6 +207,11 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 		return errors.New("VM Guest hostname is empty")
 	}
 
+	if len(oVM.Guest.Net) == 0 {
+		klog.V(4).Infof("oVM.Guest.Net is empty, skipping node discovery. This could be cauesd by vmtool not reporting correct IP address")
+		return errors.New("VM GuestNicInfo is empty")
+	}
+
 	tenantRef := vmDI.VcServer
 	if vmDI.TenantRef != "" {
 		tenantRef = vmDI.TenantRef
@@ -281,6 +286,12 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 	ipAddrNetworkNames := toIPAddrNetworkNames(nonVNICDevices)
 	nonLocalhostIPs := excludeLocalhostIPs(ipAddrNetworkNames)
 
+	if len(nonLocalhostIPs) == 0 {
+		klog.V(4).Infof("nonLocalhostIPs is empty")
+		klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
+		return fmt.Errorf("unable to find suitable IP address for node after filtering out localhost IPs")
+	}
+
 	for _, ipFamily := range ipFamilies {
 		klog.V(6).Infof("ipFamily: %q nonLocalhostIPs: %q", ipFamily, nonLocalhostIPs)
 		discoveredInternal, discoveredExternal := discoverIPs(
@@ -311,6 +322,7 @@ func (nm *NodeManager) DiscoverNode(nodeID string, searchBy cm.FindVM) error {
 
 		if len(oVM.Guest.Net) > 0 {
 			if discoveredInternal == nil && discoveredExternal == nil {
+				klog.V(4).Infof("oVM.Guest.Net=%v", oVM.Guest.Net)
 				return fmt.Errorf("unable to find suitable IP address for node %s with IP family %s", nodeID, ipFamilies)
 			}
 		}


### PR DESCRIPTION
This backports a fix for the Cloud provider node manager that fixes an issue where, after initialising correctly with IP addresses, the CCM will, after a few minutes, remove the IP addresses from the nodes.

I've observed this behaviour manually and believe, based on the descriptions of the upstream PR and issue (details in BZ) that this should resolve the issue. We aren't seeing the issue in 4.11 so I've based the BZ chain on the rebase which included this commit.