### PR TITLE
DO NOT MERGE: Fix error verification to work on Go 1.19 and 1.20

### DIFF
--- a/pkg/common/vclib/connection_test.go
+++ b/pkg/common/vclib/connection_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -188,7 +189,8 @@ func verifyWrappedX509UnkownAuthorityErr(t *testing.T, err error) {
 	if !ok {
 		t.Fatalf("Expected to receive an url.Error, got '%s' (%#v)", err.Error(), err)
 	}
-	x509Err, ok := urlErr.Err.(x509.UnknownAuthorityError)
+	x509Err := &x509.UnknownAuthorityError{}
+	ok = errors.As(urlErr.Err, x509Err)
 	if !ok {
 		t.Fatalf("Expected to receive a wrapped x509.UnknownAuthorityError, got: '%s' (%#v)", urlErr.Error(), urlErr)
 	}


### PR DESCRIPTION
Go 1.20 introduces a new tls.CertificateValidationError that wraps the x509.UnknownAuthorityError. Instead of casting to the UnknownAuthorityError directly, search the error chain for it.