### PR TITLE
Fix downstream commit detection

### DIFF
--- a/openshift-hack/verify-history.sh
+++ b/openshift-hack/verify-history.sh
@@ -40,7 +40,7 @@ while read -r message; do
     exit 1
   fi
   echo "$message"
-done < <(git log "$check_base".."$check_sha" --pretty=%s --no-merges)
+done < <(git log "$check_base".."$check_sha" --pretty=%s --no-merges --ancestry-path)
 
 echo
 echo "All looks good"


### PR DESCRIPTION
In some cases, upstream commits were included in the git log command, causing the verify-git-history test to fail because the commits did not follow name rules.