### PR TITLE
[WIP] SPLAT-2297: Implement instancesV2 and add node-label flag

### DIFF
--- a/cmd/vsphere-cloud-controller-manager/main.go
+++ b/cmd/vsphere-cloud-controller-manager/main.go
@@ -33,6 +33,7 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/loadbalancer"
+	voptions "k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere/options"
 	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphereparavirtual"
 	"k8s.io/cloud-provider/app"
 	appconfig "k8s.io/cloud-provider/app/config"
@@ -96,6 +97,8 @@ func main() {
 		// the legcay paravirtual mode is removed.
 		globalflag.Register(namedFlagSets.FlagSet("generic"), "is-legacy-paravirtual")
 	}
+
+	voptions.AddFlags(namedFlagSets.FlagSet("cloud-node-controller"))
 
 	for _, f := range namedFlagSets.FlagSets {
 		fs.AddFlagSet(f)

--- a/pkg/cloudprovider/vsphere/cloud.go
+++ b/pkg/cloudprovider/vsphere/cloud.go
@@ -184,10 +184,8 @@ func (vs *VSphere) Instances() (cloudprovider.Instances, bool) {
 }
 
 // InstancesV2 returns an implementation of cloudprovider.InstancesV2.
-//
-//	TODO: implement this for v1.20
 func (vs *VSphere) InstancesV2() (cloudprovider.InstancesV2, bool) {
-	return nil, false
+	return vs.instancesV2, true
 }
 
 // Zones returns a zones interface. Also returns true if the interface
@@ -262,6 +260,8 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 		nsxtSecretNamespace = nsxtcfg.SecretNamespace
 	}
 
+	instancesObj := newInstances(nm)
+	zonesObj := newZones(nm, cfg.Labels.Zone, cfg.Labels.Region)
 	vs := VSphere{
 		cfg:                 cfg,
 		cfgLB:               lbcfg,
@@ -270,8 +270,9 @@ func buildVSphereFromConfig(cfg *ccfg.CPIConfig, nsxtcfg *ncfg.Config, lbcfg *lc
 		nsxtSecretNamespace: nsxtSecretNamespace,
 		loadbalancer:        lb,
 		routes:              routes,
-		instances:           newInstances(nm),
-		zones:               newZones(nm, cfg.Labels.Zone, cfg.Labels.Region),
+		instances:           instancesObj,
+		instancesV2:         newInstancesV2(instancesObj, zonesObj),
+		zones:               zonesObj,
 	}
 	return &vs, nil
 }

--- a/pkg/cloudprovider/vsphere/instances_v2.go
+++ b/pkg/cloudprovider/vsphere/instances_v2.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+// This file implements the InstancesV2 interface.
+
+import (
+	"context"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog/v2"
+)
+
+var AdditionalLabels map[string]string
+
+func newInstancesV2(instances cloudprovider.Instances, zones cloudprovider.Zones) cloudprovider.InstancesV2 {
+	return &instancesV2{
+		instances: instances,
+		zones:     zones,
+	}
+}
+
+func (c *instancesV2) getProviderID(ctx context.Context, node *v1.Node) (string, error) {
+	klog.V(4).Infof("instancesV2.getProviderID() called for node %s", node.Name)
+	if node.Spec.ProviderID != "" {
+		return node.Spec.ProviderID, nil
+	}
+
+	instanceID, err := c.instances.InstanceID(ctx, types.NodeName(node.Name))
+	if err != nil {
+		return "", err
+	}
+
+	return ProviderName + "://" + instanceID, nil
+}
+
+// InstanceExists returns true if the instance for the given node exists according to the cloud provider.
+// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+func (c *instancesV2) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
+	klog.V(4).Infof("instancesV2.InstanceExists() called for node %s", node.Name)
+	providerID, err := c.getProviderID(ctx, node)
+	if err != nil {
+		return false, err
+	}
+
+	return c.instances.InstanceExistsByProviderID(ctx, providerID)
+}
+
+// InstanceShutdown returns true if the instance is shutdown according to the cloud provider.
+// Use the node.name or node.spec.providerID field to find the node in the cloud provider.
+func (c *instancesV2) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
+	klog.V(4).Infof("instancesV2.InstanceShutdown() called for node %s", node.Name)
+	providerID, err := c.getProviderID(ctx, node)
+	if err != nil {
+		return false, err
+	}
+
+	return c.instances.InstanceShutdownByProviderID(ctx, providerID)
+}
+
+func (c *instancesV2) getAdditionalLabels() (map[string]string, error) {
+	return AdditionalLabels, nil
+}
+
+// InstanceMetadata returns the instance's metadata. The values returned in InstanceMetadata are
+// translated into specific fields and labels in the Node object on registration.
+// Implementations should always check node.spec.providerID first when trying to discover the instance
+// for a given node. In cases where node.spec.providerID is empty, implementations can use other
+// properties of the node like its name, labels and annotations.
+func (c *instancesV2) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
+	klog.V(4).Infof("instancesV2.InstanceMetadata() called with node %s", node.Name)
+
+	providerID, err := c.getProviderID(ctx, node)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).Infof("instancesV2.InstanceMetadata() got provider ID %s", providerID)
+
+	instanceType, err := c.instances.InstanceTypeByProviderID(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).Infof("instancesV2.InstanceMetadata() got instanceType %s", instanceType)
+
+	zone, err := c.zones.GetZoneByProviderID(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).InfoS("instancesV2.InstanceMetadata() got zone info", "zone", zone)
+
+	nodeAddresses, err := c.instances.NodeAddressesByProviderID(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).InfoS("instancesV2.InstanceMetadata() got nodeAddresses", "nodeAddresses", nodeAddresses)
+
+	// Generate additionalLabels
+	additionalLabels, err := c.getAdditionalLabels()
+	if err != nil {
+		return nil, err
+	}
+	klog.V(4).InfoS("instancesV2.InstanceMetadata() got additionalLabels", "additionalLabels", additionalLabels)
+
+	return &cloudprovider.InstanceMetadata{
+		ProviderID:       providerID,
+		InstanceType:     instanceType,
+		NodeAddresses:    nodeAddresses,
+		Zone:             zone.FailureDomain,
+		Region:           zone.Region,
+		AdditionalLabels: additionalLabels,
+	}, nil
+}

--- a/pkg/cloudprovider/vsphere/options/flags.go
+++ b/pkg/cloudprovider/vsphere/options/flags.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/cloud-provider-vsphere/pkg/cloudprovider/vsphere"
+)
+
+// AddFlags add the additional flags for the controller
+func AddFlags(fs *pflag.FlagSet) {
+	fs.StringToStringVar(&vsphere.AdditionalLabels, "node-labels", nil, "Additional labels to add to vSphere nodes during registration.")
+}

--- a/pkg/cloudprovider/vsphere/types.go
+++ b/pkg/cloudprovider/vsphere/types.go
@@ -46,8 +46,9 @@ type VSphere struct {
 	routes       route.RoutesProvider
 
 	// cloud provider interfaces
-	instances cloudprovider.Instances
-	zones     cloudprovider.Zones
+	instances   cloudprovider.Instances
+	zones       cloudprovider.Zones
+	instancesV2 cloudprovider.InstancesV2
 	/*
 		Interfaces end
 	*/
@@ -113,6 +114,11 @@ type zones struct {
 	nodeManager *NodeManager
 	zone        string
 	region      string
+}
+
+type instancesV2 struct {
+	instances cloudprovider.Instances
+	zones     cloudprovider.Zones
 }
 
 // GuestOSLookup is a table for quick lookup between guestOsIdentifier and a shorthand name


### PR DESCRIPTION
[SPLAT-2297](https://issues.redhat.com//browse/SPLAT-2297)

### Changes
- Implemented instancesV2 to enable ability to provide additionalLabels for nodes
- Added new cmd flag to allow passing in of labels to apply to vsphere nodes

### Notes
This will be ported upstream.  Currently this PR is being used for payload testing to validate solution.

We are attempting to support a hybrid environment of vSphere with some platform=none (baremetal) nodes.  For this to happen, we need to be able to apply a platform-type label on the nodes so that our daemonsets can be configured with a nodeSelector that is unique per platform.  The 3CMO will add the new parameter to the startup of the pod allowing the vSphere CCM to add the new label.